### PR TITLE
Upgrading the library in composer.lock to make sure we get the version we need.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "typhonius/acquia-php-sdk-v2": "^2.0.0",
+        "typhonius/acquia-php-sdk-v2": "^2.0.4",
         "typhonius/acquia-logstream": "^0.3",
         "consolidation/robo": "^2",
         "symfony/lock": "^3|^4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ac4ad45c67fb8a2ee466f30bed920e1",
+    "content-hash": "92b16e3122fe9c59d38bd3c67b4c396b",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -2365,16 +2365,16 @@
         },
         {
             "name": "typhonius/acquia-php-sdk-v2",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typhonius/acquia-php-sdk-v2.git",
-                "reference": "c2ef5c8044ba53b7133fa931aab995fecc335602"
+                "reference": "e643cecd5c94d33b804a9b2a0dca769ab7142f34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typhonius/acquia-php-sdk-v2/zipball/c2ef5c8044ba53b7133fa931aab995fecc335602",
-                "reference": "c2ef5c8044ba53b7133fa931aab995fecc335602",
+                "url": "https://api.github.com/repos/typhonius/acquia-php-sdk-v2/zipball/e643cecd5c94d33b804a9b2a0dca769ab7142f34",
+                "reference": "e643cecd5c94d33b804a9b2a0dca769ab7142f34",
                 "shasum": ""
             },
             "require": {
@@ -2409,7 +2409,7 @@
                 }
             ],
             "description": "A PHP SDK for Acquia CloudAPI v2",
-            "time": "2020-01-26T01:43:30+00:00"
+            "time": "2020-02-17T01:45:15+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
If you checkout the 2.0 branch... run `composer install` and run acquiacli from commandline, you get 

```
PHP Fatal error:  Uncaught Error: Call to undefined method AcquiaCloudApi\Connector\Client::addOption() in /home/allan/.local/lib/acquia_cli/src/Commands/DbBackupCommand.php:176
Stack trace:
#0 [internal function]: AcquiaCli\Commands\DbBackupCommand->dbBackupDownload('fe919a38-2300-4...', Object(AcquiaCloudApi\Response\EnvironmentResponse), 'sdsuextension', Array)
#1 /home/allan/.local/lib/acquia_cli/vendor/consolidation/annotated-command/src/CommandProcessor.php(257): call_user_func_array(Array, Array)
#2 /home/allan/.local/lib/acquia_cli/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#3 /home/allan/.local/lib/acquia_cli/vendor/consolidation/annotated-command/src/CommandProcessor.php(178): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#4 /home/allan/.local/lib/acquia_cli/vendor/consolidation in /home/allan/.local/lib/acquia_cli/src/Commands/DbBackupCommand.php on line 176
```

This PR ensures that doesn't happen by updating the lock file... FYI this all works fine when acquiacli is a dependency of another project because composer doesn't respect the lock file there.