### PR TITLE
Fixes #48: Allows all configuration to be overwritten

### DIFF
--- a/src/Cli/CloudApi.php
+++ b/src/Cli/CloudApi.php
@@ -34,11 +34,6 @@ class CloudApi
     {
 
         $acquia = $config->get('acquia');
-
-        if (getenv('ACQUIACLI_KEY') && getenv('ACQUIACLI_SECRET')) {
-            $acquia['key'] = getenv('ACQUIACLI_KEY');
-            $acquia['secret'] = getenv('ACQUIACLI_SECRET');
-        }
         
         $connector = new Connector(
             [

--- a/src/Cli/Config.php
+++ b/src/Cli/Config.php
@@ -26,12 +26,35 @@ class Config extends RoboConfig implements GlobalOptionDefaultValuesInterface
         $globalConfig = join(DIRECTORY_SEPARATOR, [$homeDir, '.acquiacli', 'acquiacli.yml']);
         $projectConfig = join(DIRECTORY_SEPARATOR, [$root, 'acquiacli.yml']);
 
+        $environment = [];
+        if (getenv('ACQUIACLI_KEY')) {
+            $environment['acquia']['key'] = getenv('ACQUIACLI_KEY');
+        }
+        if (getenv('ACQUIACLI_SECRET')) {
+            $environment['acquia']['secret'] = getenv('ACQUIACLI_SECRET');
+        }
+        if (getenv('ACQUIACLI_TIMEZONE')) {
+            $environment['extraconfig']['timezone'] = getenv('ACQUIACLI_TIMEZONE');
+        }
+        if (getenv('ACQUIACLI_FORMAT')) {
+            $environment['extraconfig']['format'] = getenv('ACQUIACLI_FORMAT');
+        }
+        if (getenv('ACQUIACLI_TASKWAIT')) {
+            $environment['extraconfig']['taskwait'] = getenv('ACQUIACLI_TASKWAIT');
+        }
+        if (getenv('ACQUIACLI_TIMEOUT')) {
+            $environment['extraconfig']['timeout'] = getenv('ACQUIACLI_TIMEOUT');
+        }
+
         $processor->extend($loader->load($defaultConfig));
         $processor->extend($loader->load($globalConfig));
         $processor->extend($loader->load($projectConfig));
+        $processor->add($environment);
 
         $this->import($processor->export());
-        $this->set('config.project', $projectConfig);
+        $this->set('config.default', $defaultConfig);
         $this->set('config.global', $globalConfig);
+        $this->set('config.project', $projectConfig);
+        $this->set('config.environment', $environment);
     }
 }

--- a/tests/AcquiaCliApplicationTest.php
+++ b/tests/AcquiaCliApplicationTest.php
@@ -23,7 +23,7 @@ class AcquiaCliApplicationTest extends AcquiaCliTestCase
         parent::setUp();
     }
 
-    public function testConfig()
+    public function testDefaultConfig()
     {
         $config = new Config($this->root);
 
@@ -41,6 +41,42 @@ class AcquiaCliApplicationTest extends AcquiaCliTestCase
 
         $this->assertEquals($defaultAcquiaConfig, $config->get('acquia'));
         $this->assertEquals($defaultExtraConfig, $config->get('extraconfig'));
+    }
+
+    public function testEnvironmentConfig()
+    {
+        // Set environment variables so we can test configuration overrides.
+        putenv('ACQUIACLI_KEY=16fd1cde-1e66-b113-8e98-5ff9d444d54f');
+        putenv('ACQUIACLI_SECRET=SDtg0o83TrZm5gVckpaZynCxpikMqcht9u3fexWIHm7');
+        putenv('ACQUIACLI_TIMEZONE=Australia/Hobart');
+        putenv('ACQUIACLI_FORMAT=Y-m-d H:i:s (U)');
+        putenv('ACQUIACLI_TASKWAIT=2');
+        putenv('ACQUIACLI_TIMEOUT=400');
+
+        $config = new Config($this->root);
+
+        $environmentAcquiaConfig = [
+            'key' => '16fd1cde-1e66-b113-8e98-5ff9d444d54f',
+            'secret' => 'SDtg0o83TrZm5gVckpaZynCxpikMqcht9u3fexWIHm7'
+        ];
+
+        $environmentExtraConfig = [
+            'timezone' => 'Australia/Hobart',
+            'format' => 'Y-m-d H:i:s (U)',
+            'taskwait' => 2,
+            'timeout' => 400
+        ];
+
+        $this->assertEquals($environmentAcquiaConfig, $config->get('acquia'));
+        $this->assertEquals($environmentExtraConfig, $config->get('extraconfig'));
+
+        // Remove them at the end of the test so they do not interfere with other tests.
+        putenv('ACQUIACLI_KEY=');
+        putenv('ACQUIACLI_SECRET=');
+        putenv('ACQUIACLI_TIMEZONE=');
+        putenv('ACQUIACLI_FORMAT=');
+        putenv('ACQUIACLI_TASKWAIT=');
+        putenv('ACQUIACLI_TIMEOUT=');
     }
 
     public function testVersion()

--- a/tests/AcquiaCliTestCase.php
+++ b/tests/AcquiaCliTestCase.php
@@ -5,8 +5,6 @@ namespace AcquiaCli\Tests;
 use AcquiaCloudApi\Connector\Client;
 use Symfony\Component\Console\Input\ArgvInput;
 use AcquiaCli\Cli\Config;
-use Consolidation\Config\Loader\ConfigProcessor;
-use Consolidation\Config\Loader\YamlConfigLoader;
 use AcquiaCli\Cli\AcquiaCli;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Consolidation\AnnotatedCommand\CommandData;
@@ -150,10 +148,6 @@ abstract class AcquiaCliTestCase extends TestCase
         // Create an instance of the application and use some default parameters.
         $root = dirname(dirname(__DIR__));
         $config = new Config($root);
-        $loader = new YamlConfigLoader();
-        $processor = new ConfigProcessor();
-        $processor->extend($loader->load(dirname(__DIR__) . '/default.acquiacli.yml'));
-        $config->import($processor->export());
 
         array_unshift($command, 'acquiacli', '--no-wait', '--yes');
         $input = new ArgvInput($command);

--- a/tests/Commands/SetupCommandTest.php
+++ b/tests/Commands/SetupCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace AcquiaCli\Tests\Commands;
+
+use Robo\Robo;
+use AcquiaCli\Cli\Config;
+use AcquiaCli\Cli\AcquiaCli;
+use AcquiaCli\Tests\AcquiaCliTestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Consolidation\Config\Loader\ConfigProcessor;
+use Consolidation\Config\Loader\YamlConfigLoader;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class SetupCommandTest extends AcquiaCliTestCase
+{
+ 
+    public function testSetupConfigViewDefault()
+    {
+        $command = ['setup:config:view'];
+        $defaultConfiguration = <<< DEFAULT
+                                             
+             Default configuration           
+                                             
+acquia:
+  key: 'd0697bfc-7f56-4942-9205-b5686bf5b3f5'
+  secret: 'D5UfO/4FfNBWn4+0cUwpLOoFzfP7Qqib4AoY+wYGsKE='
+extraconfig:
+  timezone: 'Australia/Sydney'
+  format: 'Y-m-d H:i:s'
+  taskwait: 5
+  timeout: 300
+
+                                             
+             Running configuration           
+                                             
+acquia:
+    key: d0697bfc-7f56-4942-9205-b5686bf5b3f5
+    secret: D5UfO/4FfNBWn4+0cUwpLOoFzfP7Qqib4AoY+wYGsKE=
+extraconfig:
+    timezone: Australia/Sydney
+    format: 'Y-m-d H:i:s'
+    taskwait: 5
+    timeout: 300
+
+
+DEFAULT;
+
+        $actualResponse = $this->execute($command);
+        $this->assertSame($defaultConfiguration, $actualResponse);
+    }
+
+    public function testSetupConfigViewOverwritten()
+    {
+        $command = ['setup:config:view'];
+        $overwrittenConfiguration = <<< OVERWRITTEN
+                                             
+             Default configuration           
+                                             
+acquia:
+  key: 'd0697bfc-7f56-4942-9205-b5686bf5b3f5'
+  secret: 'D5UfO/4FfNBWn4+0cUwpLOoFzfP7Qqib4AoY+wYGsKE='
+extraconfig:
+  timezone: 'Australia/Sydney'
+  format: 'Y-m-d H:i:s'
+  taskwait: 5
+  timeout: 300
+
+                                             
+           Environment configuration         
+                                             
+extraconfig:
+    timezone: Australia/Melbourne
+    format: U
+
+                                             
+             Running configuration           
+                                             
+acquia:
+    key: d0697bfc-7f56-4942-9205-b5686bf5b3f5
+    secret: D5UfO/4FfNBWn4+0cUwpLOoFzfP7Qqib4AoY+wYGsKE=
+extraconfig:
+    timezone: Australia/Melbourne
+    format: U
+    taskwait: 5
+    timeout: 300
+
+
+OVERWRITTEN;
+
+        putenv('ACQUIACLI_TIMEZONE=Australia/Melbourne');
+        putenv('ACQUIACLI_FORMAT=U');
+
+        $actualResponse = $this->execute($command);
+        $this->assertSame($overwrittenConfiguration, $actualResponse);
+
+        putenv('ACQUIACLI_TIMEZONE=');
+        putenv('ACQUIACLI_FORMAT=');
+    }
+}


### PR DESCRIPTION
 Fixes #48: Allows all configuration to be overwritten with environment variables and refactors the setup commands.